### PR TITLE
fix calling runInContext

### DIFF
--- a/server/middleware/per-request.js
+++ b/server/middleware/per-request.js
@@ -55,6 +55,6 @@ function perRequestContextFactory(options) {
         ns.set('http', {req: req, res: res});
       }
       next();
-    });
+    }, ns);
   };
 }


### PR DESCRIPTION
Pass namespace created in middleware to `runInContext`
