### PR TITLE
[SEMVER-MAJOR] Replace continuation-local-storage with cls-hooked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,38 @@
 # loopback-context
 
 Current context for LoopBack applications, based on
-node-continuation-local-storage.
+cls-hooked.
+
+## USAGE WARNING
+
+**Only if you use this package, it's recommended to not run your app using `slc run` or `node .`**
+
+Run using (recommended):
+
+`node -r cls-hooked .`
+
+This uses the `-r` option in order to require `cls-hooked` before your app (see warnings below for more info).
+
+If you wish to use `strong-supervisor`, you would need to pass node options to `slc run`, which currently has issues, according to [strong-supervisor#56](https://github.com/strongloop/strong-supervisor/issues/56).
+
+A less reliable, less recommended way, which instead should be compatible with `strong-supervisor`, would be to add this Javascript line at the first line of your app, and no later than that (**the order of require statements matters**):
+
+`require('cls-hooked')`
+
+Warning: to rely on the order of `require` statements is error-prone.
+
+## INSTALL WARNING
+
+**Only if you use this package, do NOT install your app using `npm install`.**
+
+Install using:
+
+```
+npm config set engine-strict true
+npm install
+```
+
+This keeps you from using Node < v4.5.
 
 ## WARNING
 
@@ -13,8 +44,8 @@ As a result, loopback-context does not work in many situations, as can be
 seen from issues reported in LoopBack's
 [issue tracker](https://github.com/strongloop/loopback/issues?utf8=%E2%9C%93&q=is%3Aissue%20getCurrentcontext).
 
-If you are running on Node v6, you can try the new alternative
-[cls-hooked](https://github.com/Jeff-Lewis/cls-hooked).
+The new alternative
+[cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) is known to possibly inherit these problems if it's not imported before everything else, that's why you are required to follow the advice above if using this.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "loopback-context",
   "version": "3.0.0-alpha.1",
-  "description": "Current context for LoopBack applications, based on node-continuation-local-storage",
+  "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
-    "node": ">=4"
+    "node": "^4.5 || ^5.10 || ^6.0"
   },
   "keywords": [
     "StrongLoop",
@@ -23,9 +23,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "continuation-local-storage": "^3.1.7"
+    "cls-hooked": "^4.0.1"
   },
   "devDependencies": {
+    "async": "1.5.2",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
     "eslint": "^2.13.1",

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -5,19 +5,8 @@
 
 'use strict';
 
+var cls = require('cls-hooked');
 var domain = require('domain');
-
-// Require CLS only when using the current context feature.
-// As soon as this require is done, all the instrumentation/patching
-// of async-listener is fired which is not ideal.
-//
-// Some users observed stack overflows due to promise instrumentation
-// and other people have seen similar things:
-//   https://github.com/othiym23/async-listener/issues/57
-// It all goes away when instrumentation is disabled.
-var cls = function() {
-  return require('continuation-local-storage');
-};
 
 var LoopBackContext = module.exports;
 
@@ -85,7 +74,7 @@ LoopBackContext.createContext = function(scopeName) {
   process.context = process.context || {};
   var ns = process.context[scopeName];
   if (!ns) {
-    ns = cls().createNamespace(scopeName);
+    ns = cls.createNamespace(scopeName);
     process.context[scopeName] = ns;
     // Set up LoopBackContext.getCurrentContext()
     LoopBackContext.getCurrentContext = function() {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+-r cls-hooked


### PR DESCRIPTION
Hello, this is a quick and (not so) dirty alternative to PR #2.

Rationale:
- Personally, I still like more the approach I used in PR #2, but I just realized it needs further analysis, because I initially forgot to take into account issue [async-listener#57](https://github.com/othiym23/async-listener/issues/57).
- The quickest and most obvious way to address this is, of course, to get rid of `async-listener`, which already was the long-term goal of my previous PR, anyway. Here it just turned into an immediate goal, that's all.
- One trivial way to reach this goal immediately is to completely replace `continuation-local-storage` with `cls-hooked` **quitting any attempt to keep backward compatibility with the former**, which is exactly what I did in this PR and is the difference with my previous PR. This should make the commit `df60f13`no longer necessary, so I reverted it.
- `cls-hooked`, however (maybe `continuation-local-storage` too, I don't care), needs to be required before everything else, in order to not fail silently and catastrophically. So, I also gave proper and detailed instructions about how to do this in the README.md

Anyway, given the very short time I dedicated to this PR, I would consider this a **work-in-progress** for now.

TODO:
- Bump version to 2.0.0-alpha.1 when it's more ready for alpha release.

PS
For now, in order to make tests work, after deleting `node_modules` folder and running `npm i`, I had to run (NPM v3):

```
npm r strong-remoting
npm i strong-remoting@3.0.0-alpha.5
```

I suppose this is because [loopback PR #2696](https://github.com/strongloop/loopback/pull/2696/commits/6e1defcb1805176867fdf0101e9d5ae64a80ba75) maybe hasn't landed in `loopback-context` yet.

Also, for the same reason, if you test this branch from inside a Loopback app, make sure that `loopback-context` uses the same version of `strong-remoting` as the app.
