### PR TITLE
Add bind:true option to getCurrentContext 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ MyModel.myMethod = function(cb) {
   ctx.set('key', { foo: 'bar' });
 });
 ```
+
 ### Bind for concurrency
 
 In order to workaround the aforementioned concurrency issue with `when` (and

--- a/README.md
+++ b/README.md
@@ -62,37 +62,6 @@ This approach should be compatible with all process managers, including
 `strong-pm`. However, we feel that relying on the order of `require` statements
 is error-prone.
 
-### Bind for concurrency
-
-In order to workaround the aforementioned concurrency issue with `when` (and
-similar `Promise`-like and other libraries implementing custom queues and/or
-connection pools), it's recommended to activate context binding inside each
-HTTP request or concurrent `runInContext()` call, by using the `bind` option, as
-in this example:
-
-    var ctx = LoopBackContext.getCurrentContext({ bind: true });
-
-With the option enabled, this both creates the context, and binds the access
-methods of the context (i.e. `get` and `set`), at once.
-
-**Warning**: this only works if it's **the first expression evaluated** in every
-middleware/operation hook/`runInContext()` call etc. that uses
-`getCurrentContext`. (It must be the first expression; it may not be enough if
-it's at the first line). Explanation: you must bind the context while it's still
-correct, i.e. before it gets mixed up between concurrent operations affected by
-bugs. Therefore, to be sure, you must bind it before *any* operation.
-
-The `bind` option defaults to `false`. This is only in order to prevent breaking
-legacy apps; but if your app doesn't have such issue, then you can safely use
-`bind: true` everywhere in your app (e.g. with a
-[codemod](https://github.com/facebook/jscodeshift), or by monkey-patching
-`getCurrentContext()` globally, if you prefer an automated fashion).
-
-**Warning**: this only applies to application modules. In fact, if the module
-affected by the concurrency issue is of this kind, you can easily refactor/write
-your own code so to enable `bind`. Not if it's a 3rd-party module, nor a
-Loopback non-core module, unless you fork and fix it.
-
 ### Configure context propagation
 
 To setup your LoopBack application to create a new context for each incoming
@@ -143,6 +112,36 @@ MyModel.myMethod = function(cb) {
   ctx.set('key', { foo: 'bar' });
 });
 ```
+### Bind for concurrency
+
+In order to workaround the aforementioned concurrency issue with `when` (and
+similar `Promise`-like and other libraries implementing custom queues and/or
+connection pools), it's recommended to activate context binding inside each
+HTTP request or concurrent `runInContext()` call, by using the `bind` option, as
+in this example:
+
+    var ctx = LoopBackContext.getCurrentContext({ bind: true });
+
+With the option enabled, this both creates the context, and binds the access
+methods of the context (i.e. `get` and `set`), at once.
+
+**Warning**: this only works if it's **the first expression evaluated** in every
+middleware/operation hook/`runInContext()` call etc. that uses
+`getCurrentContext`. (It must be the first expression; it may not be enough if
+it's at the first line). Explanation: you must bind the context while it's still
+correct, i.e. before it gets mixed up between concurrent operations affected by
+bugs. Therefore, to be sure, you must bind it before *any* operation.
+
+The `bind` option defaults to `false`. This is only in order to prevent breaking
+legacy apps; but if your app doesn't have such issue, then you can safely use
+`bind: true` everywhere in your app (e.g. with a
+[codemod](https://github.com/facebook/jscodeshift), or by monkey-patching
+`getCurrentContext()` globally, if you prefer an automated fashion).
+
+**Warning**: this only applies to application modules. In fact, if the module
+affected by the concurrency issue is of this kind, you can easily refactor/write
+your own code so to enable `bind`. Not if it's a 3rd-party module, nor a
+Loopback non-core module, unless you fork and fix it.
 
 ### Use current authenticated user in remote methods
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,8 @@ Current context for LoopBack applications, based on cls-hooked.
    [Bluebird](https://www.npmjs.com/package/bluebird) instead.
 - Express middleware chains which contain a "bad" middleware (i.e. one which
   breaks context propagation inside its function body, in a way mentioned in
-  this doc) especially if called before other "good" ones needs refactoring. The
-  following lines need to be present at the beginning of the middleware body. At
-  least the "bad" one; but, as a preventive measure, they can be present in
-  every other middleware of every chain as well:
-      var badMiddleware = function(req, res, next) {
-        // added lines
-        var ctx = LoopBackContext.getCurrentContext({bind: true});
-        next = ctx.bind(next);
-        ...
+  this doc) especially if called before other "good" ones needs refactoring.
+  See usage below for details.
 
    Discussion: https://github.com/strongloop/loopback-context/issues/17
 
@@ -143,6 +136,17 @@ middleware/operation hook/`runInContext()` call etc. that uses
 it's at the first line). Explanation: you must bind the context while it's still
 correct, i.e. before it gets mixed up between concurrent operations affected by
 bugs. Therefore, to be sure, you must bind it before *any* operation.
+
+Also, with respect to the "bad", context-breaking middleware use case mentioned in "Known issues"
+before, the following 2 lines need to be present at the beginning of the middleware
+body. At least the "bad" one; but, as a preventive measure, they can be present
+in every other middleware of every chain as well, being backward-compatible:
+
+     var badMiddleware = function(req, res, next) {
+       // these 2 lines below are needed
+       var ctx = LoopBackContext.getCurrentContext({bind: true});
+       next = ctx.bind(next);
+       ...
 
 The `bind` option defaults to `false`. This is only in order to prevent breaking
 legacy apps; but if your app doesn't have such issue, then you can safely use

--- a/README.md
+++ b/README.md
@@ -8,10 +8,18 @@ Current context for LoopBack applications, based on cls-hooked.
 
 ### Known issues
 
- - [when](https://www.npmjs.com/package/when), a popular Promise
+- [when](https://www.npmjs.com/package/when), a popular Promise
    implementation, breaks context propagation. Please consider using the
    built-in `Promise` implementation provided by Node.js or
    [Bluebird](https://www.npmjs.com/package/bluebird) instead.
+- Express middleware chains which contain a "bad" middleware (i.e. one which
+  breaks context propagation inside its function body, in a way mentioned in
+  this doc) called before other "good" ones, need to be refactored. The
+  following lines need to be present at the beginning of the middleware body. At
+  least the "bad" one; but, as a preventive measure, they can be present in
+  every other middleware of every chain as well:
+      var ctx = LoopBackContext.getCurrentContext({bind: true});
+      next = ctx.bind(next);
 
    Discussion: https://github.com/strongloop/loopback-context/issues/17
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Current context for LoopBack applications, based on cls-hooked.
    [Bluebird](https://www.npmjs.com/package/bluebird) instead.
 - Express middleware chains which contain a "bad" middleware (i.e. one which
   breaks context propagation inside its function body, in a way mentioned in
-  this doc) especially if called before other "good" ones needs refactoring.
+  this doc) especially if called before other "good" ones needs refactoring,
+  in order to prevent the context from getting mixed up among HTTP requests.
   See usage below for details.
 
    Discussion: https://github.com/strongloop/loopback-context/issues/17

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ This approach should be compatible with all process managers, including
 `strong-pm`. However, we feel that relying on the order of `require` statements
 is error-prone.
 
+### Re-bind for concurrency
+
+In order to workaround the aforementioned concurrency issue with `when` (and
+similar `Promise`-like and other libraries implementing custom queues and/or
+connection pools), it's recommended to activate context re-binding inside each
+HTTP request or concurrent `runInContext()` call, by using the `bind` option, as
+in this example:
+
+    var ctx = LoopBackContext.getCurrentContext({ bind: true });
+
+The `bind` option defaults to `false` (only in order to prevent breaking legacy
+apps). But if you are writing a new app, for example, you can safely use
+`bind: true` everywhere in your app.
+
+**Warning**: this only applies to application modules. In fact, if the module
+affected by the concurrency issue is of this kind, you can easily refactor/write
+your own code so to enable `bind`. Not if it's a 3rd-party module, nor a
+Loopback non-core module, unless you fork and fix it.
 
 ### Configure context propagation
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ in this example:
 
     var ctx = LoopBackContext.getCurrentContext({ bind: true });
 
-The `bind` option defaults to `false` (only in order to prevent breaking legacy
-apps). But if you are writing a new app, for example, you can safely use
-`bind: true` everywhere in your app.
+The `bind` option defaults to `false`. This is only in order to prevent breaking
+legacy apps; but if your app doesn't have such issue, then you can safely use
+`bind: true` everywhere in your app (e.g. with a
+[codemod](https://github.com/facebook/jscodeshift), or by monkey-patching
+`getCurrentContext()` globally, if you prefer an automated fashion).
 
 **Warning**: this only applies to application modules. In fact, if the module
 affected by the concurrency issue is of this kind, you can easily refactor/write

--- a/README.md
+++ b/README.md
@@ -62,15 +62,25 @@ This approach should be compatible with all process managers, including
 `strong-pm`. However, we feel that relying on the order of `require` statements
 is error-prone.
 
-### Re-bind for concurrency
+### Bind for concurrency
 
 In order to workaround the aforementioned concurrency issue with `when` (and
 similar `Promise`-like and other libraries implementing custom queues and/or
-connection pools), it's recommended to activate context re-binding inside each
+connection pools), it's recommended to activate context binding inside each
 HTTP request or concurrent `runInContext()` call, by using the `bind` option, as
 in this example:
 
     var ctx = LoopBackContext.getCurrentContext({ bind: true });
+
+With the option enabled, this both creates the context, and binds the access
+methods of the context (i.e. `get` and `set`), at once.
+
+**Warning**: this only works if it's **the first expression evaluated** in every
+middleware/operation hook/`runInContext()` call etc. that uses
+`getCurrentContext`. (It must be the first expression; it may not be enough if
+it's at the first line). Explanation: you must bind the context while it's still
+correct, i.e. before it gets mixed up between concurrent operations affected by
+bugs. Therefore, to be sure, you must bind it before *any* operation.
 
 The `bind` option defaults to `false`. This is only in order to prevent breaking
 legacy apps; but if your app doesn't have such issue, then you can safely use

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ Current context for LoopBack applications, based on cls-hooked.
    [Bluebird](https://www.npmjs.com/package/bluebird) instead.
 - Express middleware chains which contain a "bad" middleware (i.e. one which
   breaks context propagation inside its function body, in a way mentioned in
-  this doc) called before other "good" ones, need to be refactored. The
+  this doc) especially if called before other "good" ones needs refactoring. The
   following lines need to be present at the beginning of the middleware body. At
   least the "bad" one; but, as a preventive measure, they can be present in
   every other middleware of every chain as well:
-      var ctx = LoopBackContext.getCurrentContext({bind: true});
-      next = ctx.bind(next);
+      var badMiddleware = function(req, res, next) {
+        // added lines
+        var ctx = LoopBackContext.getCurrentContext({bind: true});
+        next = ctx.bind(next);
+        ...
 
    Discussion: https://github.com/strongloop/loopback-context/issues/17
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cls-hooked": "^4.0.1"
   },
   "devDependencies": {
-    "async": "1.5.2",
+    "async-1.5.2": "file:./test/stub-modules/async-1.5.2",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
     "eslint": "^2.13.1",
@@ -34,6 +34,6 @@
     "loopback": "^3.0.0",
     "mocha": "^2.5.3",
     "supertest": "^1.2.0",
-    "when": "3.7.7"
+    "when-3.7.7": "file:./test/stub-modules/when-3.7.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-config-loopback": "^4.0.0",
     "loopback": "^3.0.0",
     "mocha": "^2.5.3",
-    "supertest": "^1.2.0"
+    "supertest": "^1.2.0",
+    "when": "3.7.7"
   }
 }

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -80,8 +80,8 @@ LoopBackContext.createContext = function(scopeName) {
     LoopBackContext.getCurrentContext = function() {
       if (ns && ns.active) {
         var boundMethods = {
-          get: ns.bind(ns.get).bind(ns),
-          set: ns.bind(ns.set).bind(ns),
+          get: ns.bind(ns.get),
+          set: ns.bind(ns.set),
         };
         var handler = {
           get: function(target, name) {

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -14,9 +14,13 @@ var LoopBackContext = module.exports;
  * Get the current context object. The context is preserved
  * across async calls, it behaves like a thread-local storage.
  *
+ * @options {Object} [options]
+ * @property {Boolean} bind Bind get/set/bind methods of the context to the
+ * context that's current at the time getCurrentContext() is invoked. This
+ * can be used to work around 3rd party code breaking CLS context propagation.
  * @returns {Namespace} The context object or null.
  */
-LoopBackContext.getCurrentContext = function() {
+LoopBackContext.getCurrentContext = function(options) {
   // A placeholder method, see LoopBackContext.createContext() for the real version
   return null;
 };
@@ -91,10 +95,12 @@ LoopBackContext.createContext = function(scopeName) {
        * you may run into unexpected issues that are fixed only for get & set.
        */
       var boundContext = Object.create(ns);
-      // Call to Function.prototype.bind(), not ns.bind()
-      boundContext.bind = ns.bind.bind(ns);
       boundContext.get = boundContext.bind(ns.get);
       boundContext.set = boundContext.bind(ns.set);
+
+      // Call to Function.prototype.bind(), not ns.bind()
+      boundContext.bind = ns.bind.bind(ns);
+
       return boundContext;
     };
   }

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -77,29 +77,23 @@ LoopBackContext.createContext = function(scopeName) {
     ns = cls.createNamespace(scopeName);
     process.context[scopeName] = ns;
     // Set up LoopBackContext.getCurrentContext()
-    LoopBackContext.getCurrentContext = function() {
-      if (ns && ns.active) {
-        /**
-         * **NOTE**
-         * This only re-binds get and set methods, the most used.
-         * If you use other methods of the context, e.g. runInContext(), etc.,
-         * you may run into unexpected issues that are fixed only for get, set.
-         */
-        var boundMethods = {
-          get: ns.bind(ns.get),
-          set: ns.bind(ns.set),
-        };
-        var handler = {
-          get: function(target, name) {
-            return ['get', 'set'].includes(name) ?
-            boundMethods[name] :
-            target[name];
-          },
-        };
-        return new Proxy(ns, handler);
-      } else {
+    LoopBackContext.getCurrentContext = function(options) {
+      if (!ns || !ns.active) {
         return null;
       }
+      if (!options || !options.bind) {
+        return ns;
+      }
+      /**
+       * **NOTE**
+       * This only re-binds get and set methods, the most used.
+       * If you use other methods of the context, e.g. runInContext(), etc.,
+       * you may run into unexpected issues that are fixed only for get & set.
+       */
+      var boundContext = Object.create(ns);
+      boundContext.get = ns.bind(ns.get);
+      boundContext.set = ns.bind(ns.set);
+      return boundContext;
     };
   }
   return ns;

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -78,7 +78,19 @@ LoopBackContext.createContext = function(scopeName) {
     process.context[scopeName] = ns;
     // Set up LoopBackContext.getCurrentContext()
     LoopBackContext.getCurrentContext = function() {
-      return ns && ns.active ? ns : null;
+      var boundMethods = {
+        get: ns.bind(ns.get).bind(ns),
+        set: ns.bind(ns.set).bind(ns),
+      };
+      var handler = {
+        get: function(target, name) {
+          return ['get', 'set'].includes(name) ?
+          boundMethods[name] :
+          target[name];
+        },
+      };
+      var proxy = new Proxy(ns, handler);
+      return ns && ns.active ? proxy : null;
     };
   }
   return ns;

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -86,13 +86,15 @@ LoopBackContext.createContext = function(scopeName) {
       }
       /**
        * **NOTE**
-       * This only re-binds get and set methods, the most used.
+       * This only re-binds get, set and bind methods, the most used.
        * If you use other methods of the context, e.g. runInContext(), etc.,
        * you may run into unexpected issues that are fixed only for get & set.
        */
       var boundContext = Object.create(ns);
-      boundContext.get = ns.bind(ns.get);
-      boundContext.set = ns.bind(ns.set);
+      // Call to Function.prototype.bind(), not ns.bind()
+      boundContext.bind = ns.bind.bind(ns);
+      boundContext.get = boundContext.bind(ns.get);
+      boundContext.set = boundContext.bind(ns.set);
       return boundContext;
     };
   }

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -78,19 +78,22 @@ LoopBackContext.createContext = function(scopeName) {
     process.context[scopeName] = ns;
     // Set up LoopBackContext.getCurrentContext()
     LoopBackContext.getCurrentContext = function() {
-      var boundMethods = {
-        get: ns.bind(ns.get).bind(ns),
-        set: ns.bind(ns.set).bind(ns),
-      };
-      var handler = {
-        get: function(target, name) {
-          return ['get', 'set'].includes(name) ?
-          boundMethods[name] :
-          target[name];
-        },
-      };
-      var proxy = new Proxy(ns, handler);
-      return ns && ns.active ? proxy : null;
+      if (ns && ns.active) {
+        var boundMethods = {
+          get: ns.bind(ns.get).bind(ns),
+          set: ns.bind(ns.set).bind(ns),
+        };
+        var handler = {
+          get: function(target, name) {
+            return ['get', 'set'].includes(name) ?
+            boundMethods[name] :
+            target[name];
+          },
+        };
+        return new Proxy(ns, handler);
+      } else {
+        return null;
+      }
     };
   }
   return ns;

--- a/server/current-context.js
+++ b/server/current-context.js
@@ -79,6 +79,12 @@ LoopBackContext.createContext = function(scopeName) {
     // Set up LoopBackContext.getCurrentContext()
     LoopBackContext.getCurrentContext = function() {
       if (ns && ns.active) {
+        /**
+         * **NOTE**
+         * This only re-binds get and set methods, the most used.
+         * If you use other methods of the context, e.g. runInContext(), etc.,
+         * you may run into unexpected issues that are fixed only for get, set.
+         */
         var boundMethods = {
           get: ns.bind(ns.get),
           set: ns.bind(ns.set),

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -162,9 +162,7 @@ describe('LoopBack Context', function() {
         var ctx = LoopBackContext.getCurrentContext(options);
         expect(ctx).is.an('object');
         ctx.set('test-key', pushedValue);
-        var whenPromise = whenV377.promise(function(resolve) {
-          setTimeout(resolve, timeout);
-        });
+        var whenPromise = whenV377().delay(timeout);
         whenPromise.then(function pullFromContextAndReturn() {
           var pulledValue = ctx && ctx.get('test-key');
           outerResolve({

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -154,7 +154,7 @@ describe('LoopBack Context', function() {
     });
   });
 
-  var timeout = 25;
+  var timeout = 100;
 
   function runWithPushedValue(pushedValue, bind) {
     return new Promise(function concurrentExecution(outerResolve, reject) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -132,10 +132,10 @@ describe('LoopBack Context', function() {
   it('handles concurrent then() calls with when v3.7.7 promises & bind option',
   function() {
     var timeout = 25;
-    function runWithPushedValue(pushedValue, bind, expectToFail) {
+    function runWithPushedValue(pushedValue) {
       return new Promise(function concurrentExecution(outerResolve, reject) {
         LoopBackContext.runInContext(function pushToContext() {
-          var ctx = LoopBackContext.getCurrentContext({bind: bind});
+          var ctx = LoopBackContext.getCurrentContext({bind: true});
           expect(ctx).is.an('object');
           ctx.set('test-key', pushedValue);
           var whenPromise = whenV377.promise(function(resolve) {
@@ -145,24 +145,15 @@ describe('LoopBack Context', function() {
             var pulledValue = ctx && ctx.get('test-key');
             return pulledValue;
           }).then(function verify(pulledValue) {
-            if (bind) {
-              expect(pulledValue).to.equal(pushedValue);
-            } else if (expectToFail) {
-              expect(pulledValue).to.not.equal(pushedValue);
-            }
+            expect(pulledValue).to.equal(pushedValue);
             outerResolve();
           }).catch(reject);
         });
       });
     }
     return Promise.all([
-      runWithPushedValue('test-value-1', true),
-      runWithPushedValue('test-value-2', true),
-    ]).then(function() {
-      return Promise.all([
-        runWithPushedValue('test-value-3'),
-        runWithPushedValue('test-value-4', false, true),
-      ]);
-    });
+      runWithPushedValue('test-value-1'),
+      runWithPushedValue('test-value-2'),
+    ]);
   });
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -151,34 +151,35 @@ describe('LoopBack Context', function() {
         });
       });
     }
-    var successfulPromise = Promise.all([
+    function getFailureCount(values) {
+      var failureCount = 0;
+      values.forEach(function(v) {
+        if (v.pulledValue !== v.pushedValue) {
+          failureCount++;
+        }
+      });
+      return failureCount;
+    }
+    var successfulRun = Promise.all([
       runWithPushedValue('test-value-1', true),
       runWithPushedValue('test-value-2', true),
     ])
     .then(function verify(values) {
-      values.forEach(function(v) {
-        expect(v.pulledValue).to.equal(v.pushedValue);
-      });
+      var failureCount = getFailureCount(values);
+      expect(failureCount).to.equal(0);
     });
-    return successfulPromise
+    return successfulRun
     .then(function() {
-      var failingPromise = Promise.all([
+      var maybeFailingRun = Promise.all([
         runWithPushedValue('test-value-3'),
         runWithPushedValue('test-value-4'),
       ])
       .then(function verify(values) {
         // Expect one of the two runners to fail, no matter which one
-        var failureCount = 0;
-        values.forEach(function(v) {
-          try {
-            expect(v.pulledValue).to.equal(v.pushedValue);
-          } catch (e) {
-            failureCount++;
-          }
-        });
+        var failureCount = getFailureCount(values);
         expect(failureCount).to.be.at.most(1);
       });
-      return failingPromise;
+      return maybeFailingRun;
     });
   });
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -133,8 +133,8 @@ describe('LoopBack Context', function() {
   it('handles concurrent then() calls with when v3.7.7 promises & bind option',
   function() {
     return Promise.all([
-      runWithPushedValue('test-value-1', true),
-      runWithPushedValue('test-value-2', true),
+      runWithPushedValue('test-value-1', {bind: true}),
+      runWithPushedValue('test-value-2', {bind: true}),
     ])
     .then(function verify(values) {
       var failureCount = getFailureCount(values);
@@ -156,10 +156,10 @@ describe('LoopBack Context', function() {
 
   var timeout = 100;
 
-  function runWithPushedValue(pushedValue, bind) {
+  function runWithPushedValue(pushedValue, options) {
     return new Promise(function concurrentExecution(outerResolve, reject) {
       LoopBackContext.runInContext(function pushToContext() {
-        var ctx = LoopBackContext.getCurrentContext({bind: bind});
+        var ctx = LoopBackContext.getCurrentContext(options);
         expect(ctx).is.an('object');
         ctx.set('test-key', pushedValue);
         var whenPromise = whenV377.promise(function(resolve) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -141,10 +141,8 @@ describe('LoopBack Context', function() {
           var whenPromise = whenV377.promise(function(resolve) {
             setTimeout(resolve, timeout);
           });
-          whenPromise.then(function pullFromContext() {
+          whenPromise.then(function pullFromContextAndReturn() {
             var pulledValue = ctx && ctx.get('test-key');
-            return pulledValue;
-          }).then(function returnValues(pulledValue) {
             outerResolve({
               pulledValue: pulledValue,
               pushedValue: pushedValue,

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -152,7 +152,6 @@ describe('LoopBack Context', function() {
       var failureCount = getFailureCount(values);
       expect(failureCount).to.be.at.most(1);
     });
-    return maybeFailingRun;
   });
 
   var timeout = 25;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -5,8 +5,8 @@
 
 'use strict';
 
-var async = require('async');
-var when = require('when');
+var asyncV152 = require('async-1.5.2');
+var whenV377 = require('when-3.7.7');
 var LoopBackContext = require('..');
 var Domain = require('domain');
 var EventEmitter = require('events').EventEmitter;
@@ -107,10 +107,9 @@ describe('LoopBack Context', function() {
   // Heavily edited by others
   it('keeps context when using waterfall() from async 1.5.2',
   function(done) {
-    expect(require('async/package.json').version).to.equal('1.5.2');
     LoopBackContext.runInContext(function() {
       // Trigger async waterfall callbacks
-      async.waterfall([
+      asyncV152.waterfall([
         function pushToContext(next) {
           var ctx = LoopBackContext.getCurrentContext();
           expect(ctx).is.an('object');
@@ -132,7 +131,6 @@ describe('LoopBack Context', function() {
   });
   it('doesn\'t mix up contexts if using concurrently then() from when 3.7.7',
   function() {
-    expect(require('when/package.json').version).to.equal('3.7.7');
     var timeout = 50;
     // Concurrent execution number 1 of 2
     var execution1 = new Promise(function execution1(outerResolve, reject) {
@@ -140,7 +138,7 @@ describe('LoopBack Context', function() {
         var ctx = LoopBackContext.getCurrentContext();
         expect(ctx).is.an('object');
         ctx.set('test-key', 'test-value-1');
-        var whenPromise = when.promise(function(resolve) {
+        var whenPromise = whenV377.promise(function(resolve) {
           setTimeout(resolve, timeout);
         });
         whenPromise.then(function pullFromContext1() {
@@ -160,7 +158,7 @@ describe('LoopBack Context', function() {
         var ctx = LoopBackContext.getCurrentContext();
         expect(ctx).is.an('object');
         ctx.set('test-key', 'test-value-2');
-        var whenPromise = when.promise(function(resolve) {
+        var whenPromise = whenV377.promise(function(resolve) {
           setTimeout(resolve, timeout);
         });
         whenPromise.then(function pullFromContext2() {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -142,7 +142,7 @@ describe('LoopBack Context', function() {
     });
   });
 
-  it('fails at most once without bind option and when v3.7.7 promises',
+  it('fails once without bind option and when v3.7.7 promises',
   function() {
     return Promise.all([
       runWithPushedValue('test-value-3'),
@@ -150,7 +150,7 @@ describe('LoopBack Context', function() {
     ])
     .then(function verify(values) {
       var failureCount = getFailureCount(values);
-      expect(failureCount).to.be.at.most(1);
+      expect(failureCount).to.equal(1);
     });
   });
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -176,7 +176,7 @@ describe('LoopBack Context', function() {
             failureCount++;
           }
         });
-        expect(failureCount).to.equal(1);
+        expect(failureCount).to.be.at.most(1);
       });
       return failingPromise;
     });

--- a/test/stub-modules/async-1.5.2/index.js
+++ b/test/stub-modules/async-1.5.2/index.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('async');

--- a/test/stub-modules/async-1.5.2/package.json
+++ b/test/stub-modules/async-1.5.2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "async-1.5.2",
+  "version": "1.5.2",
+  "description":"async version 1.5.2",
+  "dependencies": {
+    "async":"1.5.2"
+  }
+}

--- a/test/stub-modules/when-3.7.7/index.js
+++ b/test/stub-modules/when-3.7.7/index.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('when');

--- a/test/stub-modules/when-3.7.7/package.json
+++ b/test/stub-modules/when-3.7.7/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "when-3.7.7",
+  "version": "3.7.7",
+  "description":"when version 3.7.7",
+  "dependencies": {
+    "when":"3.7.7"
+  }
+}


### PR DESCRIPTION
### Description
Workaround issue #17 with cujojs/when v3.7.7 and similar packages (mostly `Promise` libraries) that use queues for async-related stuff.
**User** code is cleaner and more elegant than initially proposed in #17, because he/she only needs to remember to call `LoopBackContext.getCurrentContext()` at the first line of his/her middlewares/operation hooks which use the current context feature (if it's a remote hook, the feature should not be needed anymore; if you use it anyway, use it preferably in `beforeRemote` rather than `afterRemote`).
P.S. : use it early in the middleware/hook chain for a given route.
**Library** code, instead, can be improved a lot; this is just my first attempt. Style needs to be checked too.
Also, I only patched the context functions `get` and `set`, because I don't use other functions. I didn't patch the other functions yet (~I deleted them, whoops 😄  This aspect needs to be fixed~).

Thank you!

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #17

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added to cover all changes (the new test passes!)
- [x] Documentation changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
