### PR TITLE
fix typo in readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 ### Contributing ###
 
-Thank you for your interest in `loopback-context-cls`, an open source project
+Thank you for your interest in `loopback-context`, an open source project
 administered by StrongLoop.
 
-Contributing to `loopback-context-cls` is easy. In a few simple steps:
+Contributing to `loopback-context` is easy. In a few simple steps:
 
   * Ensure that your effort is aligned with the project's roadmap by
     talking to the maintainers, especially if you are going to spend a

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ module.exports = function(options) {
     "loopback#token": {}
   },
   "auth:after": {
-    "./middleware/set-current-user": {}
+    "./middleware/store-current-user": {}
   }
 }
 ```


### PR DESCRIPTION
### Description

Fix typo in readme and rename model name in middleware example snippet to be the same as the remote method example. Also fix the module name in contributing file.

#### Related issues

- None

### Checklist

- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
