### PR TITLE
Add NodeJS v7 to package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "7"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
-    "node": "^4.5 || ^5.10 || ^6.0"
+    "node": "^4.5 || ^5.10 || ^6.0 || ^7.0"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
### Description
Added NodeJS v7 to package.json. 
This way yarn will not complain when node 7 is used.
Tests still pass and the package itself also works on Node 7.

#### Related issues

Fixes #29 Add support for Node 7

### Checklist
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
