### PR TITLE
upgrade node engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install --save loopback-context cls-hooked
 ```
 
 Make sure you are running on a Node.js version supported by this module
-(`^4.5`, `^5.10`, `^6.0`, `^7.0` or `^8.2.1`). When installing, check the output of `npm install`
+(`^4.5`, `^5.10`, `^6.0`, `^7.0`, `^8.2.1` or `^10.14`). When installing, check the output of `npm install`
 and make sure there are no `engine` related warnings.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-context",
-  "version": "3.4.0",
+  "version": "3.3.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
     "node": "^6.0 || ^8.2.1 || ^10.14"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
-    "node": "^6.0 || ^8.2.1"
+    "node": "^6.0 || ^8.2.1 || ^10.0"
   },
   "keywords": [
     "StrongLoop",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
-    "node": "^6.0 || ^8.2.1 || ^10.0"
+    "node": ">=6.0"
   },
   "keywords": [
     "StrongLoop",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
-    "node": ">=6.0"
+    "node": "^6.0 || ^8.2.1 || ^10.14"
   },
   "keywords": [
     "StrongLoop",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-context",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
     "node": "^6.0 || ^8.2.1 || ^10.14"


### PR DESCRIPTION
### Description
Node v10 is in LTS now. Tested with node 10.14.2, and it works. 

