### PR TITLE
Node version ^10.14 added to engines list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install --save loopback-context cls-hooked
 ```
 
 Make sure you are running on a Node.js version supported by this module
-(`^4.5`, `^5.10`, `^6.0`, `^7.0` or `^8.2.1`). When installing, check the output of `npm install`
+(`^4.5`, `^5.10`, `^6.0`, `^7.0`, `^8.2.1` or `^10.14`). When installing, check the output of `npm install`
 and make sure there are no `engine` related warnings.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "description": "Current context for LoopBack applications, based on cls-hooked",
   "engines": {
-    "node": "^6.0 || ^8.2.1"
+    "node": "^6.0 || ^8.2.1 || ^10.14"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
replacing PR #42 (couldn't squash commits on that PR as all changes were made directly in github online). Closing issue #41 