### PR TITLE
Travis: enable Node.js 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "10"


### PR DESCRIPTION
This is a follow-up for #43 which added Node.js 10 to supported engines.

cc @jannyHou  @ahmetcetin 